### PR TITLE
Add form requests command option

### DIFF
--- a/src/CrudApiMake.php
+++ b/src/CrudApiMake.php
@@ -12,6 +12,7 @@ class CrudApiMake extends GeneratorCommand
     protected $signature = 'make:crud-api {name : The model name}
                             {--p|parent= : The generated API controller parent directory}
                             {--t|tests-only : Generate API CRUD testcases only}
+                            {--r|form-requests : Generate CRUD with Form Request on create and update actions}
                             {--f|formfield : Generate CRUD with FormField facades}';
 
     /**

--- a/src/CrudMake.php
+++ b/src/CrudMake.php
@@ -56,6 +56,10 @@ class CrudMake extends GeneratorCommand
         $this->generateResources();
         $this->generateTestFiles();
 
+        if ($this->option('form-requests')) {
+            $this->generateRequestClasses();
+        }
+
         $this->info('CRUD files generated successfully!');
     }
 
@@ -115,5 +119,13 @@ class CrudMake extends GeneratorCommand
         app('Luthfi\CrudGenerator\Generators\FormViewGenerator', ['command' => $this])->generate();
         app('Luthfi\CrudGenerator\Generators\IndexViewGenerator', ['command' => $this])->generate();
         app('Luthfi\CrudGenerator\Generators\ShowViewGenerator', ['command' => $this])->generate();
+    }
+
+    /**
+     * Generate Form Requests
+     */
+    public function generateRequestClasses()
+    {
+        app('Luthfi\CrudGenerator\Generators\FormRequestGenerator', ['command' => $this])->generate();
     }
 }

--- a/src/CrudMake.php
+++ b/src/CrudMake.php
@@ -13,6 +13,7 @@ class CrudMake extends GeneratorCommand
                             {--p|parent= : The generated controller parent directory}
                             {--t|tests-only : Generate CRUD testcases only}
                             {--f|formfield : Generate CRUD with FormField facades}
+                            {--r|form-requests : Generate CRUD with Form Request on create and update actions}
                             {--bs3 : Generate CRUD with Bootstrap 3 views}';
 
     /**

--- a/src/CrudSimpleMake.php
+++ b/src/CrudSimpleMake.php
@@ -13,6 +13,7 @@ class CrudSimpleMake extends GeneratorCommand
                             {--p|parent= : The generated controller parent directory}
                             {--t|tests-only : Generate CRUD testcases only}
                             {--f|formfield : Generate CRUD with FormField facades}
+                            {--r|form-requests : Generate CRUD with Form Request on create and update actions}
                             {--bs3 : Generate CRUD with Bootstrap 3 views}';
 
     /**

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -39,6 +39,10 @@ class ControllerGenerator extends BaseGenerator
      */
     public function getContent(string $stubName)
     {
+        if ($this->command->option('form-requests')) {
+            $stubName .= '-formrequests';
+        }
+
         $stub = $this->getStubFileContent($stubName);
 
         $controllerFileContent = $this->replaceStubString($stub);

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -8,7 +8,10 @@ namespace Luthfi\CrudGenerator\Generators;
 class FormRequestGenerator extends BaseGenerator
 {
     /**
-     * {@inheritDoc}
+     * Generate class file content.
+     *
+     * @param  string  $type Type of crud
+     * @return void
      */
     public function generate(string $type = 'full')
     {
@@ -16,17 +19,22 @@ class FormRequestGenerator extends BaseGenerator
         $pluralModelName = $this->modelNames['plural_model_name'];
 
         $requestPath = $this->makeDirectory(app_path('Http/Requests/'.$pluralModelName));
-        $createRequestPath = $requestPath.'/CreateRequest.php';
-        $this->generateFile($createRequestPath, $this->getContent('requests/create-request'));
 
-        $updateRequestPath = $requestPath.'/UpdateRequest.php';
-        $this->generateFile($updateRequestPath, $this->getContent('requests/update-request'));
+        $this->generateFile(
+            $requestPath.'/CreateRequest.php', $this->getContent('requests/create-request')
+        );
+        $this->generateFile(
+            $requestPath.'/UpdateRequest.php', $this->getContent('requests/update-request')
+        );
 
         $this->command->info($modelName.' Form Requests generated.');
     }
 
     /**
-     * {@inheritDoc}
+     * Get class file content.
+     *
+     * @param  string  $stubName Name of stub file
+     * @return string
      */
     public function getContent(string $stubName)
     {

--- a/src/Generators/FormRequestGenerator.php
+++ b/src/Generators/FormRequestGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Luthfi\CrudGenerator\Generators;
+
+/**
+ * Form Request Generator Class
+ */
+class FormRequestGenerator extends BaseGenerator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(string $type = 'full')
+    {
+        $modelName = $this->modelNames['model_name'];
+        $pluralModelName = $this->modelNames['plural_model_name'];
+
+        $requestPath = $this->makeDirectory(app_path('Http/Requests/'.$pluralModelName));
+        $createRequestPath = $requestPath.'/CreateRequest.php';
+        $this->generateFile($createRequestPath, $this->getContent('requests/create-request'));
+
+        $updateRequestPath = $requestPath.'/UpdateRequest.php';
+        $this->generateFile($updateRequestPath, $this->getContent('requests/update-request'));
+
+        $this->command->info($modelName.' Form Requests generated.');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getContent(string $stubName)
+    {
+        $stub = $this->getStubFileContent($stubName);
+
+        $controllerFileContent = $this->replaceStubString($stub);
+
+        $appNamespace = $this->getAppNamespace();
+
+        $controllerFileContent = str_replace(
+            "App\Http\Controllers",
+            "{$appNamespace}Http\Controllers",
+            $controllerFileContent
+        );
+
+        return $controllerFileContent;
+    }
+}

--- a/src/stubs/controllers/full-formrequests.stub
+++ b/src/stubs/controllers/full-formrequests.stub
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use fullMstr;
+use Illuminate\Http\Request;
+
+class MasterController extends Controller
+{
+    /**
+     * Display a listing of the singleMstr.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        $singleMstrQuery = Master::query();
+        $singleMstrQuery->where('name', 'like', '%'.request('q').'%');
+        $mstrCollections = $singleMstrQuery->paginate(25);
+
+        return view('masters.index', compact('mstrCollections'));
+    }
+
+    /**
+     * Show the form for creating a new singleMstr.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function create()
+    {
+        $this->authorize('create', new Master);
+
+        return view('masters.create');
+    }
+
+    /**
+     * Store a newly created singleMstr in storage.
+     *
+     * @param  \App\Http\Requests\Masters\CreateRequest  $createMasterForm
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function store(CreateRequest $createMasterForm)
+    {
+        $singleMstr = $createMasterForm->save();
+
+        return redirect()->route('masters.show', $singleMstr);
+    }
+
+    /**
+     * Display the specified singleMstr.
+     *
+     * @param  \App\Master  $singleMstr
+     * @return \Illuminate\View\View
+     */
+    public function show(Master $singleMstr)
+    {
+        return view('masters.show', compact('singleMstr'));
+    }
+
+    /**
+     * Show the form for editing the specified singleMstr.
+     *
+     * @param  \App\Master  $singleMstr
+     * @return \Illuminate\View\View
+     */
+    public function edit(Master $singleMstr)
+    {
+        $this->authorize('update', $singleMstr);
+
+        return view('masters.edit', compact('singleMstr'));
+    }
+
+    /**
+     * Update the specified singleMstr in storage.
+     *
+     * @param  \App\Http\Requests\Masters\UpdateRequest  $singleMstrUpdateForm
+     * @param  \fullMstr  $singleMstr
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function update(UpdateRequest $singleMstrUpdateForm, Master $singleMstr)
+    {
+        $singleMstr->update($singleMstrUpdateForm->validated());
+
+        return redirect()->route('masters.show', $singleMstr);
+    }
+
+    /**
+     * Remove the specified singleMstr from storage.
+     *
+     * @param  \fullMstr  $singleMstr
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function destroy(Master $singleMstr)
+    {
+        $this->authorize('delete', $singleMstr);
+
+        request()->validate([
+            'master_id' => 'required',
+        ]);
+
+        if (request('master_id') == $singleMstr->id && $singleMstr->delete()) {
+            $routeParam = request()->only('page', 'q');
+
+            return redirect()->route('masters.index', $routeParam);
+        }
+
+        return back();
+    }
+}

--- a/src/stubs/controllers/full-formrequests.stub
+++ b/src/stubs/controllers/full-formrequests.stub
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use fullMstr;
 use Illuminate\Http\Request;
+use App\Http\Requests\Masters\CreateRequest;
+use App\Http\Requests\Masters\UpdateRequest;
 
 class MasterController extends Controller
 {

--- a/src/stubs/requests/create-request.stub
+++ b/src/stubs/requests/create-request.stub
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Masters;
+
+use fullMstr;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->can('create', new Master);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name'        => 'required|max:60',
+            'description' => 'nullable|max:255',
+        ];
+    }
+
+    /**
+     * Save proposal to database.
+     *
+     * @return \fullMstr
+     */
+    public function save()
+    {
+        $newMaster = $this->validated();
+        $newMaster['creator_id'] = auth()->id();
+
+        return Master::create($newMaster);
+    }
+}

--- a/src/stubs/requests/update-request.stub
+++ b/src/stubs/requests/update-request.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Masters;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->can('update', $this->route('master'));
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name'        => 'required|max:60',
+            'description' => 'nullable|max:255',
+        ];
+    }
+}

--- a/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
+++ b/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
@@ -49,6 +49,8 @@ namespace App\Http\Controllers;
 
 use {$this->full_model_name};
 use Illuminate\Http\Request;
+use App\Http\Requests\\{$this->plural_model_name}\CreateRequest;
+use App\Http\Requests\\{$this->plural_model_name}\UpdateRequest;
 
 class {$this->model_name}Controller extends Controller
 {

--- a/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
+++ b/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\CommandOptions;
+
+use Tests\TestCase;
+
+class FullCrudFormRequestOptionsTest extends TestCase
+{
+    /** @test */
+    public function it_can_generate_controller_file_with_form_requests_class()
+    {
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true, '--form-requests' => true]);
+
+        $this->assertFileExists(app_path("Http/Controllers/{$this->model_name}Controller.php"));
+        $ctrlClassContent = "<?php
+
+namespace App\Http\Controllers;
+
+use {$this->full_model_name};
+use Illuminate\Http\Request;
+
+class {$this->model_name}Controller extends Controller
+{
+    /**
+     * Display a listing of the {$this->single_model_var_name}.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        \${$this->single_model_var_name}Query = {$this->model_name}::query();
+        \${$this->single_model_var_name}Query->where('name', 'like', '%'.request('q').'%');
+        \${$this->collection_model_var_name} = \${$this->single_model_var_name}Query->paginate(25);
+
+        return view('{$this->table_name}.index', compact('{$this->collection_model_var_name}'));
+    }
+
+    /**
+     * Show the form for creating a new {$this->single_model_var_name}.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function create()
+    {
+        \$this->authorize('create', new {$this->model_name});
+
+        return view('{$this->table_name}.create');
+    }
+
+    /**
+     * Store a newly created {$this->single_model_var_name} in storage.
+     *
+     * @param  \App\Http\Requests\\{$this->plural_model_name}\CreateRequest  \$create{$this->model_name}Form
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function store(CreateRequest \$create{$this->model_name}Form)
+    {
+        \${$this->single_model_var_name} = \$create{$this->model_name}Form->save();
+
+        return redirect()->route('{$this->table_name}.show', \${$this->single_model_var_name});
+    }
+
+    /**
+     * Display the specified {$this->single_model_var_name}.
+     *
+     * @param  \\{$this->full_model_name}  \${$this->single_model_var_name}
+     * @return \Illuminate\View\View
+     */
+    public function show({$this->model_name} \${$this->single_model_var_name})
+    {
+        return view('{$this->table_name}.show', compact('{$this->single_model_var_name}'));
+    }
+
+    /**
+     * Show the form for editing the specified {$this->single_model_var_name}.
+     *
+     * @param  \\{$this->full_model_name}  \${$this->single_model_var_name}
+     * @return \Illuminate\View\View
+     */
+    public function edit({$this->model_name} \${$this->single_model_var_name})
+    {
+        \$this->authorize('update', \${$this->single_model_var_name});
+
+        return view('{$this->table_name}.edit', compact('{$this->single_model_var_name}'));
+    }
+
+    /**
+     * Update the specified {$this->single_model_var_name} in storage.
+     *
+     * @param  \App\Http\Requests\\{$this->plural_model_name}\UpdateRequest  \${$this->single_model_var_name}UpdateForm
+     * @param  \\{$this->full_model_name}  \${$this->single_model_var_name}
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function update(UpdateRequest \${$this->single_model_var_name}UpdateForm, {$this->model_name} \${$this->single_model_var_name})
+    {
+        \${$this->single_model_var_name}->update(\${$this->single_model_var_name}UpdateForm->validated());
+
+        return redirect()->route('{$this->table_name}.show', \${$this->single_model_var_name});
+    }
+
+    /**
+     * Remove the specified {$this->single_model_var_name} from storage.
+     *
+     * @param  \\{$this->full_model_name}  \${$this->single_model_var_name}
+     * @return \Illuminate\Routing\Redirector
+     */
+    public function destroy({$this->model_name} \${$this->single_model_var_name})
+    {
+        \$this->authorize('delete', \${$this->single_model_var_name});
+
+        request()->validate([
+            '{$this->lang_name}_id' => 'required',
+        ]);
+
+        if (request('{$this->lang_name}_id') == \${$this->single_model_var_name}->id && \${$this->single_model_var_name}->delete()) {
+            \$routeParam = request()->only('page', 'q');
+
+            return redirect()->route('{$this->table_name}.index', \$routeParam);
+        }
+
+        return back();
+    }
+}
+";
+        $this->assertEquals($ctrlClassContent, file_get_contents(app_path("Http/Controllers/{$this->model_name}Controller.php")));
+    }
+}


### PR DESCRIPTION
In this PR, we add `--form-requests` command option. This option will:
- Generate `CreateRequest` and `UpdateRequest` class in `app\Http\Requests\PluralModelName` directory
- Generate a controller that uses `CreateRequest` class in store method, and uses `UpdateRequest` in update method.