### PR TITLE
Generate CRUD files for the existing model with confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/.phpunit.result.cache

--- a/src/CrudMake.php
+++ b/src/CrudMake.php
@@ -33,8 +33,11 @@ class CrudMake extends GeneratorCommand
         $this->getModelName();
 
         if ($this->modelExists()) {
-            $this->error("{$this->modelNames['model_name']} model already exists.");
-            return;
+            $confirm = $this->confirm('Model file exists, are you sure to generate CRUD files?', 'no');
+            if (in_array($confirm, ['yes', 'y']) == false) {
+                $this->error("{$this->modelNames['model_name']} model already exists.");
+                return;
+            }
         }
 
         // Warn if it has no default layout view based on

--- a/tests/CrudMakeCommandTest.php
+++ b/tests/CrudMakeCommandTest.php
@@ -36,42 +36,43 @@ class CrudMakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_cannot_generate_crud_files_if_model_exists()
+    public function it_generates_crud_files_for_existing_model()
     {
+        $this->mockConsoleOutput = true;
         $this->artisan('make:model', ['name' => $this->model_name, '--no-interaction' => true]);
-        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
-
-        $this->assertContains("{$this->model_name} model already exists.", app(Kernel::class)->output());
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true])
+            ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', 'yes');
 
         $this->assertFileExists(app_path($this->model_name.'.php'));
-        $this->assertFileNotExists(app_path("Http/Controllers/{$this->model_name}Controller.php"));
+        $this->assertFileExists(app_path("Http/Controllers/{$this->model_name}Controller.php"));
 
         $migrationFilePath = database_path('migrations/'.date('Y_m_d_His').'_create_'.$this->table_name.'_table.php');
-        $this->assertFileNotExists($migrationFilePath);
+        $this->assertFileExists($migrationFilePath);
 
-        $this->assertFileNotExists(resource_path("views/{$this->table_name}/index.blade.php"));
-        $this->assertFileNotExists(resource_path("views/{$this->table_name}/create.blade.php"));
-        $this->assertFileNotExists(resource_path("views/{$this->table_name}/edit.blade.php"));
+        $this->assertFileExists(resource_path("views/{$this->table_name}/index.blade.php"));
+        $this->assertFileExists(resource_path("views/{$this->table_name}/create.blade.php"));
+        $this->assertFileExists(resource_path("views/{$this->table_name}/edit.blade.php"));
         $this->assertFileNotExists(resource_path("views/{$this->table_name}/forms.blade.php"));
 
         $localeConfig = config('app.locale');
-        $this->assertFileNotExists(resource_path("lang/{$localeConfig}/{$this->lang_name}.php"));
+        $this->assertFileExists(resource_path("lang/{$localeConfig}/{$this->lang_name}.php"));
 
-        $this->assertFileNotExists(base_path("routes/web.php"));
-        $this->assertFileNotExists(app_path("Policies/{$this->model_name}Policy.php"));
-        $this->assertFileNotExists(database_path("factories/{$this->model_name}Factory.php"));
-        $this->assertFileNotExists(base_path("tests/Unit/Models/{$this->model_name}Test.php"));
-        $this->assertFileNotExists(base_path("tests/Unit/Policies/{$this->model_name}PolicyTest.php"));
-        $this->assertFileNotExists(base_path("tests/Feature/Manage{$this->model_name}Test.php"));
+        $this->assertFileExists(base_path("routes/web.php"));
+        $this->assertFileExists(app_path("Policies/{$this->model_name}Policy.php"));
+        $this->assertFileExists(database_path("factories/{$this->model_name}Factory.php"));
+        $this->assertFileExists(base_path("tests/Unit/Models/{$this->model_name}Test.php"));
+        $this->assertFileExists(base_path("tests/Unit/Policies/{$this->model_name}PolicyTest.php"));
+        $this->assertFileExists(base_path("tests/Feature/Manage{$this->model_name}Test.php"));
     }
 
     /** @test */
     public function it_cannot_generate_crud_files_if_namespaced_model_exists()
     {
+        $this->mockConsoleOutput = true;
         $this->artisan('make:model', ['name' => 'Entities/Projects/Problem', '--no-interaction' => true]);
-        $this->artisan('make:crud', ['name' => 'Entities/Projects/Problem', '--no-interaction' => true]);
-
-        $this->assertContains("Problem model already exists.", app(Kernel::class)->output());
+        $this->artisan('make:crud', ['name' => 'Entities/Projects/Problem', '--no-interaction' => true])
+            ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', 'no')
+            ->expectsOutput('Problem model already exists.');
 
         $this->assertFileExists(app_path('Entities/Projects/Problem.php'));
         $this->assertFileNotExists(app_path("Http/Controllers/ProblemsController.php"));

--- a/tests/CrudSimpleMakeCommandTest.php
+++ b/tests/CrudSimpleMakeCommandTest.php
@@ -36,10 +36,11 @@ class CrudSimpleCommandTest extends TestCase
     /** @test */
     public function it_cannot_generate_crud_files_if_model_exists()
     {
+        $this->mockConsoleOutput = true;
         $this->artisan('make:model', ['name' => $this->model_name, '--no-interaction' => true]);
-        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
-
-        $this->assertContains("{$this->model_name} model already exists.", app(Kernel::class)->output());
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true])
+            ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', 'no')
+            ->expectsOutput("{$this->model_name} model already exists.");
 
         $this->assertFileExists(app_path($this->model_name.'.php'));
         $this->assertFileNotExists(app_path("Http/Controllers/{$this->model_name}Controller.php"));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends BaseTestCase
         $this->model_name = 'MemberType';
 
         $this->full_model_name = 'App\\'.$this->model_name;
-        $this->plural_model_name = str_plural($this->model_name);
+        $this->plural_model_name = Str::plural($this->model_name);
         $this->table_name = Str::snake($this->plural_model_name);
         $this->lang_name = Str::snake($this->model_name);
         $this->collection_model_var_name = Str::camel($this->plural_model_name);


### PR DESCRIPTION
In this PR, we are allowing the command to generate CRUD scaffolds for an existing model. This is for answering #24 

- [x] Add confirmation dialog before generating CRUD for a model
- [x] Update tests