### PR TITLE
[2.x] Publish stub files for customization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,7 @@ The generated functional tests will give you examples of how to adapt this code 
 You can configure your own by publishing the config file:
 
 ```bash
-$ php artisan vendor:publish --provider="Luthfi\CrudGenerator\ServiceProvider"
+$ php artisan vendor:publish --provider="Luthfi\CrudGenerator\ServiceProvider" --tag=config
 ```
 
 That will generate `config/simple-crud.php` file.

--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,18 @@ return [
 
 <br>
 
+## Publishing Stub Files
+
+Stub files is the templates which we use to generate the code for each model classes and files. We can customize the stub files as we needed by publishing them to our project directory.
+
+```bash
+$ php artisan vendor:publish --provider="Luthfi\CrudGenerator\ServiceProvider" --tag=stubs
+```
+
+That will generate stub files on `stubs/simple-crud` directory. Now we can change some stub files based on our project needs.
+
+<br>
+
 ## Attention
 
 - The package will creates the **Model** class file, the command will stop if the **Model already exists**.

--- a/src/Generators/BaseGenerator.php
+++ b/src/Generators/BaseGenerator.php
@@ -116,6 +116,12 @@ abstract class BaseGenerator implements GeneratorContract
      */
     protected function getStubFileContent(string $stubName)
     {
+        $publishedStubPath = base_path('stubs/simple-crud/'.$stubName.'.stub');
+
+        if (is_file($publishedStubPath)) {
+            return $this->files->get($publishedStubPath);
+        }
+
         return $this->files->get(__DIR__.'/../stubs/'.$stubName.'.stub');
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,5 +27,9 @@ class ServiceProvider extends BaseServiceProvider
         $this->publishes([
             __DIR__.'/config.php' => config_path('simple-crud.php'),
         ], 'config');
+
+        $this->publishes([
+            __DIR__.'/stubs' => base_path('stubs/simple-crud'),
+        ], 'stubs');
     }
 }

--- a/src/stubs/controllers/api.stub
+++ b/src/stubs/controllers/api.stub
@@ -11,6 +11,7 @@ class MasterController extends Controller
     /**
      * Get a listing of the singleMstr.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function index(Request $request)

--- a/src/stubs/controllers/full-formrequests.stub
+++ b/src/stubs/controllers/full-formrequests.stub
@@ -12,6 +12,7 @@ class MasterController extends Controller
     /**
      * Display a listing of the singleMstr.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\View\View
      */
     public function index(Request $request)

--- a/src/stubs/controllers/full.stub
+++ b/src/stubs/controllers/full.stub
@@ -10,6 +10,7 @@ class MasterController extends Controller
     /**
      * Display a listing of the singleMstr.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\View\View
      */
     public function index(Request $request)

--- a/src/stubs/controllers/simple.stub
+++ b/src/stubs/controllers/simple.stub
@@ -10,6 +10,7 @@ class MasterController extends Controller
     /**
      * Display a listing of the singleMstr.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\View\View
      */
     public function index(Request $request)

--- a/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
+++ b/tests/CommandOptions/FullCrudFormRequestOptionsTest.php
@@ -57,6 +57,7 @@ class {$this->model_name}Controller extends Controller
     /**
      * Display a listing of the {$this->single_model_var_name}.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)

--- a/tests/Generators/Api/ApiControllerGeneratorTest.php
+++ b/tests/Generators/Api/ApiControllerGeneratorTest.php
@@ -25,6 +25,7 @@ class {$this->model_name}Controller extends Controller
     /**
      * Get a listing of the {$this->single_model_var_name}.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\Http\JsonResponse
      */
     public function index(Request \$request)

--- a/tests/Generators/FullControllerGeneratorTest.php
+++ b/tests/Generators/FullControllerGeneratorTest.php
@@ -24,6 +24,7 @@ class {$this->model_name}Controller extends Controller
     /**
      * Display a listing of the {$this->single_model_var_name}.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)
@@ -155,6 +156,7 @@ class CategoryController extends Controller
     /**
      * Display a listing of the category.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)
@@ -287,6 +289,7 @@ class CategoryController extends Controller
     /**
      * Display a listing of the category.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)

--- a/tests/Generators/ModelFactoryGeneratorTest.php
+++ b/tests/Generators/ModelFactoryGeneratorTest.php
@@ -39,4 +39,46 @@ class {$this->model_name}Factory extends Factory
 ";
         $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
     }
+
+    /** @test */
+    public function it_creates_model_factory_file_content_from_published_stub()
+    {
+        app('files')->makeDirectory(base_path('stubs/simple-crud/database/factories'), 0777, true, true);
+        app('files')->copy(
+            __DIR__.'/../stubs/database/factories/model-factory.stub',
+            base_path('stubs/simple-crud/database/factories/model-factory.stub')
+        );
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
+
+        $modelFactoryPath = database_path('factories/'.$this->model_name.'Factory.php');
+        $this->assertFileExists($modelFactoryPath);
+        $modelFactoryContent = "<?php
+
+declare(strict_types = 1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use {$this->full_model_name};
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class {$this->model_name}Factory extends Factory
+{
+    protected \$model = {$this->model_name}::class;
+
+    public function definition()
+    {
+        return [
+            'title'       => \$this->faker->word,
+            'description' => \$this->faker->sentence,
+            'creator_id'  => function () {
+                return User::factory()->create()->id;
+            },
+        ];
+    }
+}
+";
+        $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
+        $this->removeFileOrDir(base_path('stubs'));
+    }
 }

--- a/tests/Generators/Simple/SimpleControllerGeneratorTest.php
+++ b/tests/Generators/Simple/SimpleControllerGeneratorTest.php
@@ -24,6 +24,7 @@ class {$this->model_name}Controller extends Controller
     /**
      * Display a listing of the {$this->single_model_var_name}.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)
@@ -128,6 +129,7 @@ class CategoryController extends Controller
     /**
      * Display a listing of the category.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)
@@ -233,6 +235,7 @@ class CategoryController extends Controller
     /**
      * Display a listing of the category.
      *
+     * @param  \Illuminate\Http\Request  \$request
      * @return \Illuminate\View\View
      */
     public function index(Request \$request)

--- a/tests/stubs/database/factories/model-factory.stub
+++ b/tests/stubs/database/factories/model-factory.stub
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use fullMstr;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MasterFactory extends Factory
+{
+    protected $model = Master::class;
+
+    public function definition()
+    {
+        return [
+            'title'       => $this->faker->word,
+            'description' => $this->faker->sentence,
+            'creator_id'  => function () {
+                return User::factory()->create()->id;
+            },
+        ];
+    }
+}


### PR DESCRIPTION
In this PR, we are:
- [x] Add stub files publish feature for customization
- [x] Complete index method docblocks for controllers
- [x] Update readme.md

This PR related to #22 but made for Laravel 8.x and beyond.

## How to use

- Run:
  ```
  $ php artisan vendor:publish --provider="Luthfi\CrudGenerator\ServiceProvider" --tag=stubs
  ```
- The stub files will be located on:
  ```
  app/
  ...
  stubs/simple-crud/
  tests/
  ```
- Modify any stub files as needed
- We can remove any unchanged stub files (or leave them there if they don't bother you)