### PR TITLE
[1.x] Bugfix: Prevent Class Overrides for the Existing Models

### DIFF
--- a/src/Generators/ModelFactoryGenerator.php
+++ b/src/Generators/ModelFactoryGenerator.php
@@ -16,6 +16,7 @@ class ModelFactoryGenerator extends BaseGenerator
         $modelFactoryClassPath = $modelFactoryPath.'/'.$this->modelNames['model_name'].'Factory.php';
 
         if ($this->files->exists($modelFactoryClassPath)) {
+            $this->command->warn('Use the existing '.$this->modelNames['model_name'].' model factory.');
             return;
         }
 

--- a/src/Generators/ModelFactoryGenerator.php
+++ b/src/Generators/ModelFactoryGenerator.php
@@ -13,9 +13,14 @@ class ModelFactoryGenerator extends BaseGenerator
     public function generate(string $type = 'full')
     {
         $modelFactoryPath = $this->makeDirectory(database_path('factories'));
+        $modelFactoryClassPath = $modelFactoryPath.'/'.$this->modelNames['model_name'].'Factory.php';
+
+        if ($this->files->exists($modelFactoryClassPath)) {
+            return;
+        }
 
         $this->generateFile(
-            $modelFactoryPath.'/'.$this->modelNames['model_name'].'Factory.php',
+            $modelFactoryClassPath,
             $this->getContent('database/factories/model-factory')
         );
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -14,11 +14,13 @@ class ModelGenerator extends BaseGenerator
     {
         $modelPath = $this->modelNames['model_path'];
         $modelDirectory = $this->makeDirectory(app_path($modelPath));
+        $modelClassPath = $modelDirectory.'/'.$this->modelNames['model_name'].'.php';
 
-        $this->generateFile(
-            $modelDirectory.'/'.$this->modelNames['model_name'].'.php',
-            $this->getContent('models/model')
-        );
+        if ($this->files->exists($modelClassPath)) {
+            return;
+        }
+
+        $this->generateFile($modelClassPath, $this->getContent('models/model'));
 
         $this->command->info($this->modelNames['model_name'].' model generated.');
     }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -17,6 +17,7 @@ class ModelGenerator extends BaseGenerator
         $modelClassPath = $modelDirectory.'/'.$this->modelNames['model_name'].'.php';
 
         if ($this->files->exists($modelClassPath)) {
+            $this->command->warn('Use the existing '.$this->modelNames['model_name'].' model.');
             return;
         }
 

--- a/src/Generators/ModelPolicyGenerator.php
+++ b/src/Generators/ModelPolicyGenerator.php
@@ -20,6 +20,7 @@ class ModelPolicyGenerator extends BaseGenerator
         $modelPolicyClassPath = $modelPolicyPath.'/'.$this->modelNames['model_name'].'Policy.php';
 
         if ($this->files->exists($modelPolicyClassPath)) {
+            $this->command->warn('Use the existing '.$this->modelNames['model_name'].' model policy.');
             return;
         }
 

--- a/src/Generators/ModelPolicyGenerator.php
+++ b/src/Generators/ModelPolicyGenerator.php
@@ -17,11 +17,13 @@ class ModelPolicyGenerator extends BaseGenerator
             $parentDirectory = '/'.$this->command->option('parent');
         }
         $modelPolicyPath = $this->makeDirectory(app_path('Policies'.$parentDirectory));
+        $modelPolicyClassPath = $modelPolicyPath.'/'.$this->modelNames['model_name'].'Policy.php';
 
-        $this->generateFile(
-            $modelPolicyPath.'/'.$this->modelNames['model_name'].'Policy.php',
-            $this->getContent('models/model-policy')
-        );
+        if ($this->files->exists($modelPolicyClassPath)) {
+            return;
+        }
+
+        $this->generateFile($modelPolicyClassPath, $this->getContent('models/model-policy'));
 
         $this->command->info($this->modelNames['model_name'].' model policy generated.');
 

--- a/tests/Generators/ModelFactoryGeneratorTest.php
+++ b/tests/Generators/ModelFactoryGeneratorTest.php
@@ -74,4 +74,45 @@ class {$this->model_name}Factory extends Factory
         $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
         $this->removeFileOrDir(base_path('stubs'));
     }
+
+    /** @test */
+    public function it_doesnt_override_the_existing_model_factory_content()
+    {
+        // $this->artisan('make:model', ['name' => 'Models/'.$this->model_name, '--no-interaction' => true]);
+        $this->artisan('make:factory', ['name' => $this->model_name.'Factory', '--no-interaction' => true]);
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
+
+        $modelFactoryPath = database_path('factories/'.$this->model_name.'Factory.php');
+        $this->assertFileExists($modelFactoryPath);
+        $modelFactoryContent = "<?php
+
+namespace Database\Factories;
+
+use App\Model;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class {$this->model_name}Factory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected \$model = Model::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}
+";
+        $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
+    }
 }

--- a/tests/Generators/ModelFactoryGeneratorTest.php
+++ b/tests/Generators/ModelFactoryGeneratorTest.php
@@ -78,7 +78,6 @@ class {$this->model_name}Factory extends Factory
     /** @test */
     public function it_doesnt_override_the_existing_model_factory_content()
     {
-        // $this->artisan('make:model', ['name' => 'Models/'.$this->model_name, '--no-interaction' => true]);
         $this->artisan('make:factory', ['name' => $this->model_name.'Factory', '--no-interaction' => true]);
         $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
 

--- a/tests/Generators/ModelFactoryGeneratorTest.php
+++ b/tests/Generators/ModelFactoryGeneratorTest.php
@@ -85,32 +85,16 @@ class {$this->model_name}Factory extends Factory
         $this->assertFileExists($modelFactoryPath);
         $modelFactoryContent = "<?php
 
-namespace Database\Factories;
+/* @var \$factory \Illuminate\Database\Eloquent\Factory */
 
 use App\Model;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Faker\Generator as Faker;
 
-class {$this->model_name}Factory extends Factory
-{
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
-    protected \$model = Model::class;
-
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
-    public function definition()
-    {
-        return [
-            //
-        ];
-    }
-}
+\$factory->define(Model::class, function (Faker \$faker) {
+    return [
+        //
+    ];
+});
 ";
         $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
     }

--- a/tests/Generators/ModelGeneratorTest.php
+++ b/tests/Generators/ModelGeneratorTest.php
@@ -98,11 +98,11 @@ class Category extends Model
         $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true])
             ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', true);
 
-        $modelPath = app_path('Models/'.$this->model_name.'.php');
+        $modelPath = app_path($this->model_name.'.php');
         $this->assertFileExists($modelPath);
         $modelClassContent = "<?php
 
-namespace App\Models;
+namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Generators/ModelGeneratorTest.php
+++ b/tests/Generators/ModelGeneratorTest.php
@@ -94,8 +94,7 @@ class Category extends Model
     public function it_doesnt_override_the_existing_model()
     {
         $this->mockConsoleOutput = true;
-        config(['auth.providers.users.model' => 'App\Models\User']);
-        $this->artisan('make:model', ['name' => 'Models/'.$this->model_name, '--no-interaction' => true]);
+        $this->artisan('make:model', ['name' => $this->model_name, '--no-interaction' => true]);
         $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true])
             ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', true);
 
@@ -105,12 +104,11 @@ class Category extends Model
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class {$this->model_name} extends Model
 {
-    use HasFactory;
+    //
 }
 ";
         $this->assertEquals($modelClassContent, file_get_contents($modelPath));

--- a/tests/Generators/ModelGeneratorTest.php
+++ b/tests/Generators/ModelGeneratorTest.php
@@ -89,4 +89,30 @@ class Category extends Model
         $this->removeFileOrDir(resource_path('views/categories'));
         $this->removeFileOrDir(resource_path("lang/en/category.php"));
     }
+
+    /** @test */
+    public function it_doesnt_override_the_existing_model()
+    {
+        $this->mockConsoleOutput = true;
+        config(['auth.providers.users.model' => 'App\Models\User']);
+        $this->artisan('make:model', ['name' => 'Models/'.$this->model_name, '--no-interaction' => true]);
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true])
+            ->expectsQuestion('Model file exists, are you sure to generate CRUD files?', true);
+
+        $modelPath = app_path('Models/'.$this->model_name.'.php');
+        $this->assertFileExists($modelPath);
+        $modelClassContent = "<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class {$this->model_name} extends Model
+{
+    use HasFactory;
+}
+";
+        $this->assertEquals($modelClassContent, file_get_contents($modelPath));
+    }
 }

--- a/tests/Generators/ModelPolicyGeneratorTest.php
+++ b/tests/Generators/ModelPolicyGeneratorTest.php
@@ -229,4 +229,40 @@ class AuthServiceProvider extends ServiceProvider
 ";
         $this->assertEquals($authSPContent, file_get_contents($authSPPath));
     }
+
+    /** @test */
+    public function it_doesnt_override_the_existing_model_policy_content()
+    {
+        $userModel = config('auth.providers.users.model');
+
+        $this->artisan('make:policy', ['name' => $this->model_name.'Policy', '--no-interaction' => true]);
+        $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
+
+        $modelPolicyPath = app_path('Policies/'.$this->model_name.'Policy.php');
+        // dd(file_get_contents($modelPolicyPath));
+        $this->assertFileExists($modelPolicyPath);
+        $modelPolicyContent = "<?php
+
+namespace App\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use {$userModel};
+
+class {$this->model_name}Policy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}
+";
+        $this->assertEquals($modelPolicyContent, file_get_contents($modelPolicyPath));
+    }
 }

--- a/tests/Generators/ModelPolicyGeneratorTest.php
+++ b/tests/Generators/ModelPolicyGeneratorTest.php
@@ -244,8 +244,8 @@ class AuthServiceProvider extends ServiceProvider
 
 namespace App\Policies;
 
-use Illuminate\Auth\Access\HandlesAuthorization;
 use {$userModel};
+use Illuminate\Auth\Access\HandlesAuthorization;
 
 class {$this->model_name}Policy
 {

--- a/tests/Generators/ModelPolicyGeneratorTest.php
+++ b/tests/Generators/ModelPolicyGeneratorTest.php
@@ -239,7 +239,6 @@ class AuthServiceProvider extends ServiceProvider
         $this->artisan('make:crud', ['name' => $this->model_name, '--no-interaction' => true]);
 
         $modelPolicyPath = app_path('Policies/'.$this->model_name.'Policy.php');
-        // dd(file_get_contents($modelPolicyPath));
         $this->assertFileExists($modelPolicyPath);
         $modelPolicyContent = "<?php
 


### PR DESCRIPTION
In this PR, we are preventing class content override when generating CRUD scaffolds for an existing model. Fixes #33 

When we run the `make:crud` command for an existing model and answering `yes` on the confirmation question:

- [x] Prevent override model content
- [x] Prevent override model factory content
- [x] Prevent override model policy content
- [x] Add console warn for the existing class files