### PR TITLE
Resolving DB Factory Namespace Issue

### DIFF
--- a/src/Generators/ModelFactoryGenerator.php
+++ b/src/Generators/ModelFactoryGenerator.php
@@ -51,6 +51,12 @@ class ModelFactoryGenerator extends BaseGenerator
             $modelFactoryFileContent = str_replace($string, $replacement, $modelFactoryFileContent);
         }
 
+        if ($this->modelNames['model_path'] != 'Models') {
+            $string = 'Database\Factories';
+            $replacement = $string.'\\'.str_replace('/', '\\', $this->modelNames['model_path']);
+            $modelFactoryFileContent = str_replace($string, $replacement, $modelFactoryFileContent);
+        }
+
         return $this->replaceStubString($modelFactoryFileContent);
     }
 }

--- a/src/Generators/ModelFactoryGenerator.php
+++ b/src/Generators/ModelFactoryGenerator.php
@@ -12,7 +12,11 @@ class ModelFactoryGenerator extends BaseGenerator
      */
     public function generate(string $type = 'full')
     {
-        $modelFactoryPath = $this->makeDirectory(database_path('factories'));
+        $modelFactoryPath = database_path('factories');
+        if ($this->modelNames['model_path'] != 'Models') {
+            $modelFactoryPath .= '/'.$this->modelNames['model_path'];
+        }
+        $modelFactoryPath = $this->makeDirectory($modelFactoryPath);
         $modelFactoryClassPath = $modelFactoryPath.'/'.$this->modelNames['model_name'].'Factory.php';
 
         if ($this->files->exists($modelFactoryClassPath)) {

--- a/tests/CrudApiMakeCommandTest.php
+++ b/tests/CrudApiMakeCommandTest.php
@@ -115,7 +115,7 @@ class CrudApiMakeCommandTest extends TestCase
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
         $this->assertFileExists(app_path("Policies/{$modelName}Policy.php"));
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(base_path("tests/Feature/Api/Manage{$modelName}Test.php"));
@@ -148,7 +148,7 @@ class CrudApiMakeCommandTest extends TestCase
         $localeConfig = config('app.locale');
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(app_path("Policies/{$parentName}/{$modelName}Policy.php"));

--- a/tests/CrudMakeCommandTest.php
+++ b/tests/CrudMakeCommandTest.php
@@ -128,7 +128,7 @@ class CrudMakeCommandTest extends TestCase
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
         $this->assertFileExists(app_path("Policies/{$modelName}Policy.php"));
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(base_path("tests/Feature/Manage{$modelName}Test.php"));
@@ -163,7 +163,7 @@ class CrudMakeCommandTest extends TestCase
         $localeConfig = config('app.locale');
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(app_path("Policies/{$parentName}/{$modelName}Policy.php"));

--- a/tests/CrudSimpleMakeCommandTest.php
+++ b/tests/CrudSimpleMakeCommandTest.php
@@ -121,7 +121,7 @@ class CrudSimpleMakeCommandTest extends TestCase
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
         $this->assertFileExists(app_path("Policies/{$modelName}Policy.php"));
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(base_path("tests/Feature/Manage{$modelName}Test.php"));
@@ -154,7 +154,7 @@ class CrudSimpleMakeCommandTest extends TestCase
         $localeConfig = config('app.locale');
         $this->assertFileExists(resource_path("lang/{$localeConfig}/{$langName}.php"));
 
-        $this->assertFileExists(database_path("factories/{$modelName}Factory.php"));
+        $this->assertFileExists(database_path("factories/{$inputName}Factory.php"));
         $this->assertFileExists(base_path("tests/Unit/Models/{$modelName}Test.php"));
         $this->assertFileExists(base_path("tests/Unit/Policies/{$modelName}PolicyTest.php"));
         $this->assertFileExists(app_path("Policies/{$parentName}/{$modelName}Policy.php"));

--- a/tests/Generators/ModelFactoryGeneratorTest.php
+++ b/tests/Generators/ModelFactoryGeneratorTest.php
@@ -41,6 +41,50 @@ class {$this->model_name}Factory extends Factory
     }
 
     /** @test */
+    public function it_creates_correct_model_factory_content_with_namespaced_model()
+    {
+        $inputName = 'Entities/References/Category';
+        $modelName = 'Category';
+        $fullModelName = 'App\Entities\References\Category';
+        $pluralModelName = 'Categories';
+        $tableName = 'categories';
+        $langName = 'category';
+        $modelPath = 'Entities/References';
+        $factoryNamespace = 'Entities\References';
+
+        $this->artisan('make:crud-api', ['name' => $inputName, '--no-interaction' => true]);
+
+        $modelFactoryPath = database_path('factories/'.$inputName.'Factory.php');
+        $this->assertFileExists($modelFactoryPath);
+        $modelFactoryContent = "<?php
+
+namespace Database\Factories\\{$factoryNamespace};
+
+use App\Models\User;
+use {$fullModelName};
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class {$modelName}Factory extends Factory
+{
+    protected \$model = {$modelName}::class;
+
+    public function definition()
+    {
+        return [
+            'title'       => \$this->faker->word,
+            'description' => \$this->faker->sentence,
+            'creator_id'  => function () {
+                return User::factory()->create()->id;
+            },
+        ];
+    }
+}
+";
+        $this->assertEquals($modelFactoryContent, file_get_contents($modelFactoryPath));
+    }
+
+
+    /** @test */
     public function it_creates_model_factory_file_content_from_published_stub()
     {
         app('files')->makeDirectory(base_path('stubs/simple-crud/database/factories'), 0777, true, true);


### PR DESCRIPTION
## Description

In this PR, we are resolving #39, where we are creating the model factory class within subdirectories and updating the class namespace.

- [x] Store the generated model factory class into subdirectories
- [x] Update the model factory class namespace.

## How to test on localhost

1. `$ laravel new simple_crud_test`
2. `$ cd simple_crud_test`
2. Update `phpunit.xml` using sqlite in memory database
    ```
    <server name="DB_CONNECTION" value="sqlite"/>
    <server name="DB_DATABASE" value=":memory:"/>
    ```
3. `$ composer require laravel/ui`
4. `$ composer require luthfi/simple-crud-generator dev-39_db_factory_namespace_issue --dev`
5. `$ php artisan ui bootstrap --auth`
4. `$ php artisan make:crud Phone` (`Phone` model on the `app/Models` directory)
5. `$ vendor/bin/phpunit` (all tests are passed)
6. `$ php artisan make:crud Entities/Units/Unit` (`Unit` model on the `app/Entities/Units/Unit` directory)
7. `$ vendor/bin/phpunit --stop-on-failure`
8.  **All tests should be passed** (`UnitFactory` on the `database/factories/Entities/Units` directory).

## Screenshot

![screen_2021-04-20_010](https://user-images.githubusercontent.com/8721551/115355987-c76c0b80-a1ed-11eb-844c-0e23319c54b0.jpg)

