### PR TITLE
Fixed installation command and Laravel version in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,12 @@ The main purpose of this package is for **faster Test-driven Development**, it g
 
 ## How to install
 
+#### For Laravel 9.x
+
+```bash
+# Get the package
+$ composer require luthfi/simple-crud-generator:^3.0
+```
 #### For Laravel 8.x
 
 ```bash


### PR DESCRIPTION
I noticed the Readme had an installation version 2 and Laravel 8, but you have a v 3 for Laravel 9, and your v2 doesn't meet the requirements of Laravel 9. Readme now has all version compatibities.